### PR TITLE
docs: fix simple typo, convinience -> convenience

### DIFF
--- a/py2c/tree/node_gen.py
+++ b/py2c/tree/node_gen.py
@@ -276,7 +276,7 @@ def generate(source_dir, output_dir=None, update=False):  # coverage: not missin
     if output_dir is None:
         output_dir = source_dir
 
-    # A convinience function for printing the notifications
+    # A convenience function for printing the notifications
     def report(*args):
         print("[py2c.tree.node_gen]", *args)
 


### PR DESCRIPTION
There is a small typo in py2c/tree/node_gen.py.

Should read `convenience` rather than `convinience`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md